### PR TITLE
Fix function call in Transform3d documentation

### DIFF
--- a/pytorch3d/transforms/transform3d.py
+++ b/pytorch3d/transforms/transform3d.py
@@ -21,7 +21,7 @@ class Transform3d:
         points = torch.randn(N, P, 3)
         normals = torch.randn(N, P, 3)
         points_transformed = t.transform_points(points)    # => (N, P, 3)
-        normals_transformed = t.transform_points(normals)  # => (N, P, 3)
+        normals_transformed = t.transform_normals(normals)  # => (N, P, 3)
 
 
     BROADCASTING


### PR DESCRIPTION
The documentation of `Transform3d` highlights that the class handles points as well as normals. However, `transform_points` is applied to points and normals in the documentation instead of using `transform_normals` for normals, which I believe was intended.

This pull request fixes this typo in the documentation.